### PR TITLE
add console.info

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,5 +1,5 @@
 /**
- * It handles `console.log`, `console.warn`, `console.dir`, and `console.error` methods and not catched errors. By default, it just reflects all console messages in the Action Logger Panel (should be installed as a peerDependency) except [HMR] logs.
+ * It handles `console.log`, `console.warn`, `console.dir`, `console.error` and `console.info` methods and not catched errors. By default, it just reflects all console messages in the Action Logger Panel (should be installed as a peerDependency) except [HMR] logs.
  * @module @storybook/addon-console
  *
  *
@@ -22,6 +22,7 @@ const cLogger = {
   warn: logger.warn.bind(logger),
   error: logger.error.bind(logger),
   dir: logger.dir.bind(logger),
+  info: logger.info.bind(logger),
 };
 
 /**
@@ -34,6 +35,7 @@ const cLogger = {
  * @property {string} [warn = warn] - Optional. The marker to display warnings in Action Logger
  * @property {string} [error = error] - Optional. The marker to display errors in Action Logger
  * @property {string} [dir = dir] - Optional. The marker to display `console.dir` outputs in Action Logger
+ * @property {string} [info = info] - Optional. The marker to display `console.info` outputs in Action Logger
  */
 const addonOptions = {
   panelExclude: [/\[HMR\]/],
@@ -44,6 +46,7 @@ const addonOptions = {
   warn: 'warn',
   error: 'error',
   dir: 'dir',
+  info: 'info',
 };
 
 let currentOptions = addonOptions;
@@ -53,6 +56,7 @@ const createLogger = options => ({
   warn: action(options.warn),
   error: action(options.error),
   dir: action(options.dir),
+  info: action(options.info),
 });
 
 const shouldDisplay = (messages, exclude, include) => {
@@ -99,6 +103,13 @@ function setScope(options) {
     const toConsole = shouldDisplay(args, consoleExclude, consoleInclude);
     if (toPanel.length) aLogger.dir(...toPanel);
     if (toConsole.length) cLogger.dir(...toConsole);
+  };
+
+  logger.info = (...args) => {
+    const toPanel = shouldDisplay(args, panelExclude, panelInclude);
+    const toConsole = shouldDisplay(args, consoleExclude, consoleInclude);
+    if (toPanel.length) aLogger.info(...toPanel);
+    if (toConsole.length) cLogger.info(...toConsole);
   };
 
   global.onerror = (...args) => {
@@ -188,6 +199,7 @@ function addConsole(storyFn, context, consoleOptions) {
         warn: `${context.kind}/${context.story}/warn`,
         error: `${context.kind}/${context.story}/error`,
         dir: `${context.kind}/${context.story}/dir`,
+        info: `${context.kind}/${context.story}/info`,
       }
     : {};
 
@@ -213,7 +225,7 @@ function addConsole(storyFn, context, consoleOptions) {
 
 /**
  * Wraps your stories with specified addon options.
- * If you don't pass {`log`, `warn`, `error`, `dir`} in options argument it'll create them from context for each story individually. Hence you'll see from what exact story you got a log or error. You can log from component's lifecycle methods or within your story.
+ * If you don't pass {`log`, `warn`, `error`, `dir`, `info`} in options argument it'll create them from context for each story individually. Hence you'll see from what exact story you got a log or error. You can log from component's lifecycle methods or within your story.
  * @param {addonOptions|optionsCallback} [optionsOrFn]
  * @see [addonOptions]{@link #storybookaddon-consolesetconsoleoptionsoptionsorfn--addonoptions}
  * @see [optionsCallback]{@link #storybookaddon-consoleoptionscallback--addonoptions}

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -6,12 +6,14 @@ const consoleLog = jest.fn();
 const consoleWarn = jest.fn();
 const consoleError = jest.fn();
 const consoleDir = jest.fn();
+const consoleInfo = jest.fn();
 
 global.console = {
   log: consoleLog,
   warn: consoleWarn,
   error: consoleError,
   dir: consoleDir,
+  info: consoleInfo,
 };
 
 const { withConsole, setConsoleOptions } = require('./');
@@ -43,6 +45,7 @@ describe('addon Console', () => {
     warn: 'warn',
     error: 'error',
     dir: 'dir',
+    info: 'info',
   };
   describe('global scope', () => {
     describe('check options `setConsoleOptions`', () => {
@@ -112,6 +115,13 @@ describe('addon Console', () => {
         expect(aLogResults.msg).toBe(defaultOptions.dir);
         expect(aLogResults.data).toEqual([logString]);
         expect(consoleDir.mock.calls[0]).toEqual([logString]);
+      });
+
+      it('should output `console.info` to panel and console', () => {
+        logger.info(logString);
+        expect(aLogResults.msg).toBe(defaultOptions.info);
+        expect(aLogResults.data).toEqual([logString]);
+        expect(consoleInfo.mock.calls[0]).toEqual([logString]);
       });
 
       it('should catch error and output to panel and console', () => {
@@ -195,6 +205,11 @@ describe('addon Console', () => {
       });
       it('should not dir anything at all', () => {
         logger.dir(logString);
+        expect(aLogResults).toEqual({});
+        expect(consoleLog.mock.calls[0]).toBeUndefined();
+      });
+      it('should not info anything at all', () => {
+        logger.info(logString);
         expect(aLogResults).toEqual({});
         expect(consoleLog.mock.calls[0]).toBeUndefined();
       });


### PR DESCRIPTION
Hi all, 

Using this addon to demo our logger util in a project but found that `info`, `debug` and `trace` aren't supported. So this fork adds `info` and its tests as a bit of a tester to get your feedback and see if this is the correct approach. 

I've followed a previous PR ([console.dir](https://github.com/storybookjs/storybook-addon-console/pull/75)), so hopefully it should just be the same process.

Thanks, 
Jake
